### PR TITLE
Update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,17 @@
     "branchPrefix": "deps/",
     "packageRules": [
         {
+            "matchDepNames": ["php"],
             "matchManagers": ["composer"],
+            "enabled": false
+        },
+        {
+            "matchDepNames": ["node", "yarn"],
+            "matchManagers": ["npm"],
+            "enabled": false
+        },
+        {
+            "matchManagers": ["npm", "composer"],
             "matchUpdateTypes": ["major"],
             "enabled": false
         },


### PR DESCRIPTION
Updated renovate config via 🤠 RepoRanger.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Updates the renovate configuration to disable specific automated dependency updates across the project's package managers.

## Changes

- **Disable PHP updates**: Adds a package rule to disable automatic updates of PHP dependencies via Composer
- **Disable Node/Yarn updates**: Adds a package rule to disable automatic updates of Node.js and Yarn dependencies via npm
- **Disable major version updates**: Adds a package rule to disable major version updates for both npm and Composer managers

The configuration extends the recommended renovate preset and maintains the existing automerge, branch prefix, and dependency dashboard settings. All three new packageRules set `enabled: false` to prevent automatic PRs for these specific update types while allowing other dependency updates to be handled automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->